### PR TITLE
Fix Dependabot private-registry resolution (@hillwoodpark scope)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@hillwoodpark:registry=https://npm.pkg.github.com


### PR DESCRIPTION
Dependabot's npm updater now requires an explicit scope→registry mapping when a package.json consumes a private `@hillwoodpark/*` package (`@hillwoodpark/gcp-logger`). Without a `.npmrc` mapping the scope, the updater aborts at file-fetch with `private_registry_config_not_found`. This adds a single-line `.npmrc` at the repo root that tells Dependabot to resolve `@hillwoodpark/*` packages via `npm.pkg.github.com`; it contains no token — Dependabot injects auth from the `registries` block in `dependabot.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)